### PR TITLE
Bugfixes for ansible-php-fpm role.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
 
 - name: Add the OS specific varibles
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ ansible_os_family }}.yml" 
+
+- name: Create www-data Group
+  group: name=www-data state=present
+
+- name: Create www-data User
+  user: name=www-data comment="www-data" group=www-data
 
 - name: Install the php packages (APT)
   apt: name={{ item }} state=present update_cache=yes

--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -126,4 +126,4 @@ error_log = /var/log/php5-fpm.log
 
 ; To configure the pools it is recommended to have one .conf file per
 ; pool in the following directory:
-include={{php_fpm_pool_d}}*.conf
+include={{php_fpm_pool_d}}/*.conf


### PR DESCRIPTION
1) Fixed directory path in template as it is missing a slash while including files from /etc/php-fpm.d/
2) Creates www-data user and group if not present. (Tested on a base Amazon AMI and by default they are not present)