### PR TITLE
Fixed ansible 2.1.0 deprecations

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
     state=present
     update_cache=yes
     cache_valid_time={{ apt_cache_valid_time }}
-  with_items: php_fpm_apt_packages
+  with_items: "{{ php_fpm_apt_packages }}"
   environment: "{{ env }}"
   when: ansible_os_family == "Debian"
   notify:
@@ -18,7 +18,7 @@
 
 - name: Install the php packages (YUM)
   yum: name={{ item }} state=present
-  with_items: php_fpm_yum_packages
+  with_items: "{{ php_fpm_yum_packages }}"
   environment: "{{ env }}"
   when: ansible_os_family == "RedHat"
   notify:
@@ -32,7 +32,7 @@
     option="{{ item.option }}"
     value="{{ item.value }}"
     backup=yes
-  with_items: php_fpm_ini
+  with_items: "{{ php_fpm_ini }}"
   notify:
    - restart php-fpm
   tags: [configuration,php,fpm]
@@ -49,7 +49,7 @@
     option="{{ item.option }}"
     value="{{ item.value }}"
     backup=yes
-  with_items: php_fpm_config
+  with_items: "{{ php_fpm_config }}"
   register: copy_fpm_config
   notify:
    - restart php-fpm
@@ -92,7 +92,7 @@
     src=pool.conf.j2
     dest={{ php_fpm_pool_d }}/{{ item['name'] }}.conf
     backup=yes
-  with_items: php_fpm_pools
+  with_items: "{{ php_fpm_pools }}"
   when: php_fpm_pools|lower != 'none'
   notify:
    - restart php-fpm


### PR DESCRIPTION
Fixes all the new deprecation warnings:

`[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{php_fpm_yum_packages}}'). This 
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`