### PR TITLE
Make php-fpm error log configurable

### DIFF
--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -31,7 +31,7 @@ pid = {{ php_fpm_pid_file }}
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php5-fpm.log
+error_log = {{ php_fpm_error_log }}
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,3 +7,4 @@ php_fpm_binary_name: php5-fpm
 php_fpm_service_name: php5-fpm
 
 php_fpm_pid_file: /var/run/php5-fpm.pid
+php_fpm_error_log: /var/log/php5-fpm.log

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,3 +7,4 @@ php_fpm_binary_name: php-fpm
 php_fpm_service_name: php-fpm
 
 php_fpm_pid_file: /var/run/php-fpm/php-fpm.pid
+php_fpm_error_log: /var/log/php-fpm/php-fpm.log


### PR DESCRIPTION
Introduced 'php_fpm_error_log' variable with default settings based on 'ansible_os_family' to make it configurable.