### PR TITLE
Fix debian binary name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 apt_cache_valid_time: 86400
 
-php_fpm_version: 5.6
+php_fpm_version: 5
 
 php_fpm_default_pool:
   delete: yes

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,9 +1,9 @@
 ---
-php_fpm_ini_path: /etc/php/{{php_fpm_version}}/fpm/php.ini
-php_fpm_config_path: /etc/php/{{php_fpm_version}}/fpm/php-fpm.conf
-php_fpm_pool_d: /etc/php/{{php_fpm_version}}/fpm/pool.d
+php_fpm_ini_path: /etc/php{{php_fpm_version}}/fpm/php.ini
+php_fpm_config_path: /etc/php{{php_fpm_version}}/fpm/php-fpm.conf
+php_fpm_pool_d: /etc/php{{php_fpm_version}}/fpm/pool.d
 
 php_fpm_binary_name: php-fpm{{php_fpm_version}}
 php_fpm_service_name: php{{php_fpm_version}}-fpm
 
-php_fpm_pid_file: /var/run/php/php{{php_fpm_version}}-fpm.pid
+php_fpm_pid_file: /var/run/php{{php_fpm_version}}-fpm.pid

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,7 +3,7 @@ php_fpm_ini_path: /etc/php{{php_fpm_version}}/fpm/php.ini
 php_fpm_config_path: /etc/php{{php_fpm_version}}/fpm/php-fpm.conf
 php_fpm_pool_d: /etc/php{{php_fpm_version}}/fpm/pool.d
 
-php_fpm_binary_name: php-fpm{{php_fpm_version}}
+php_fpm_binary_name: php{{php_fpm_version}}-fpm
 php_fpm_service_name: php{{php_fpm_version}}-fpm
 
 php_fpm_pid_file: /var/run/php{{php_fpm_version}}-fpm.pid


### PR DESCRIPTION
This MR fixes an error during the task `Check php-fpm syntax of configuration files` where the binary name was wrong for debian based installation.