### PR TITLE
Add optional listen_host and listen_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Example configuration
        - name: bar
          user: www-data
          group: www-data
-         listen: 8001
+         # Add the host and port in separate variables.
+         listen_host: 127.0.0.1
+         # Attention: One of listen_port or listen is required!
+         listen_port: 8001
          env:
            PATH: "/usr/local/bin:/usr/bin:/bin"
            TMPDIR: "/tmp"

--- a/templates/pool.conf.j2
+++ b/templates/pool.conf.j2
@@ -3,7 +3,19 @@
 
 [{{ item.name }}]
 
-{% for directive, value in ((php_fpm_pool_defaults|default(dict())).items() + item.items()) if directive != "name" %}
+{% set pools_directives = ((php_fpm_pool_defaults|default(dict())).items() + item.items()) %}
+{% set pools_directives_dict = dict(pools_directives) %}
+
+{% if 'listen_host' in pools_directives_dict.keys() and 'listen_port' in pools_directives_dict.keys() %}
+listen = {{ pools_directives_dict['listen_host'] }}:{{ pools_directives_dict['listen_port'] }}
+{% elif 'listen_port' in pools_directives_dict.keys() %}
+listen = {{ pools_directives_dict['listen_port'] }}
+{% elif 'listen' in pools_directives_dict.keys() %}
+listen = {{ pools_directives_dict['listen'] }}
+{% endif %}
+
+
+{% for directive, value in pools_directives if directive not in ("name", "listen", "listen_host", "listen_port") %}
 {% if value is mapping -%}
 {% for key, value2 in value.iteritems() %}
 {{ directive }}[{{ key }}] = {{ value2 }}

--- a/templates/pool.conf.j2
+++ b/templates/pool.conf.j2
@@ -1,26 +1,28 @@
 ;{{ ansible_managed }}
 
-
 [{{ item.name }}]
+{% set pools_directives = php_fpm_pool_defaults | default(dict()) | combine(item) -%}
 
-{% set pools_directives = ((php_fpm_pool_defaults|default(dict())).items() + item.items()) %}
-{% set pools_directives_dict = dict(pools_directives) %}
+{% set listen = '' -%}
+{% if 'listen_port' in pools_directives -%}
+    {% if 'listen_host' in pools_directives -%}
+        {% set listen = listen ~ pools_directives['listen_host'] + ':' %}
+    {%- endif %}
+    {% set listen = listen ~ pools_directives['listen_port'] %}
+{% elif 'listen' in pools_directives -%}
+    {% set listen = pools_directives['listen'] %}
+{%- endif %}
 
-{% if 'listen_host' in pools_directives_dict.keys() and 'listen_port' in pools_directives_dict.keys() %}
-listen = {{ pools_directives_dict['listen_host'] }}:{{ pools_directives_dict['listen_port'] }}
-{% elif 'listen_port' in pools_directives_dict.keys() %}
-listen = {{ pools_directives_dict['listen_port'] }}
-{% elif 'listen' in pools_directives_dict.keys() %}
-listen = {{ pools_directives_dict['listen'] }}
-{% endif %}
+{% if listen -%}
+listen={{ listen }}
+{%- endif %}
 
-
-{% for directive, value in pools_directives if directive not in ("name", "listen", "listen_host", "listen_port") %}
+{% for directive, value in pools_directives.items() if directive not in ("name", "listen", "listen_host", "listen_port") -%}
 {% if value is mapping -%}
-{% for key, value2 in value.iteritems() %}
+{% for key, value2 in value.iteritems() -%}
 {{ directive }}[{{ key }}] = {{ value2 }}
-{% endfor %}
-{% else %}
+{%- endfor %}
+{%- else %}
 {{ directive }} = {{ value }}
 {% endif %}
-{% endfor %}
+{%- endfor %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,12 +6,18 @@
      - name: foo
        user: www-data
        group: www-data
-       listen: 8000
+       listen: 7000
        chdir: /
      - name: bar
        user: www-data
        group: www-data
-       listen: 9000
+       listen_port: 8000
+       chdir: /
+     - name: baz
+       user: www-data
+       group: www-data
+       listen_host: 127.0.0.1
+       listen_port: 9000
        chdir: /
   roles:
     - role_under_test


### PR DESCRIPTION
Now it is possible to define the host and port for the listen directive in separate arguments (listen_host and listen_port).
They will be combined to listen=host:port.
This new arguments are superior over listen