### PR TITLE
fix pool config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Example configuration
            TMPDIR: "/tmp"
          php_admin_value:
            sendmail_path: "/usr/sbin/sendmail -t -i -f www@my.domain.com"
-           error_log = "/var/log/fpm-bar.www.log"
+           error_log: "/var/log/fpm-bar.www.log"
        php_fpm_ini:
        # PHP section directives
        - option: "engine"

--- a/templates/pool.conf.j2
+++ b/templates/pool.conf.j2
@@ -18,11 +18,11 @@ listen={{ listen }}
 {%- endif %}
 
 {% for directive, value in pools_directives.items() if directive not in ("name", "listen", "listen_host", "listen_port") -%}
-{% if value is mapping -%}
-{% for key, value2 in value.iteritems() -%}
+{% if value is mapping %}
+{% for key, value2 in value.iteritems() %}
 {{ directive }}[{{ key }}] = {{ value2 }}
-{%- endfor %}
-{%- else %}
+{% endfor %}
+{% else %}
 {{ directive }} = {{ value }}
 {% endif %}
 {%- endfor %}


### PR DESCRIPTION
- new lines ignored for mapping values resulted in invalid generated nginx file
- Fixed readme typo