### PR TITLE
Added conversion to int in Debian version comparison

### DIFF
--- a/tasks/1-install.yml
+++ b/tasks/1-install.yml
@@ -9,7 +9,7 @@
 - include: 1-install-Debian.yml
   when:
     - ansible_distribution == "Debian"
-    - ansible_distribution_version >= 8
+    - ansible_distribution_version|int >= 8
 
 - name: Install the php packages (APT)
   apt: >


### PR DESCRIPTION
The related error:

`fatal: [<hostname>]: FAILED! => {"msg": "The conditional check 'ansible_distribution_version >= 8' failed. The error was: Unexpected templating type error occurred on ({% if ansible_distribution_version >= 8 %} True {% else %} False {% endif %}): '>=' not supported between instances of 'AnsibleUnsafeText' and 'int'\n\nThe error appears to have been in '/project-dir/ansible-ooxoo/roles/nbz4live.php-fpm/tasks/1-install-Debian.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Make sure sury.org repository can be used (Debian)\n  ^ here\n"}`